### PR TITLE
🐛  fix: package.json without name property

### DIFF
--- a/src/jobs/getProjectName.ts
+++ b/src/jobs/getProjectName.ts
@@ -2,40 +2,19 @@ import { Uri, workspace } from "vscode";
 
 export default async (currentUri: Uri) => {
   const pattern = 'package.json';
-
-  let projectName = '';
-  let packageUri = undefined;
+  const rootFolder = workspace.workspaceFolders![0];
 
   const [packageCurrentUri] = await workspace.findFiles({
     base: currentUri.path,
     pattern,
   });
 
-  if (packageCurrentUri) {
-    packageUri = packageCurrentUri;
-  }
+  if (!packageCurrentUri) {return rootFolder.name;};
 
-  const rootFolderUri = workspace.workspaceFolders![0].uri;
+  const contentInBytes = await workspace.fs.readFile(packageCurrentUri);
+  const content = contentInBytes.toString();
 
-  const [packageRootFolder] = await workspace.findFiles({
-    base: rootFolderUri.path,
-    pattern,
-  });
+  const packageFile = JSON.parse(content);
 
-  if (packageRootFolder && packageUri === undefined) {
-    packageUri = packageRootFolder;
-  }
-
-  if (packageUri) {
-    const contentInBytes = await workspace.fs.readFile(packageUri);
-    const content = contentInBytes.toString();
-
-    const packageFile = JSON.parse(content);
-
-    projectName = packageFile.name as string;
-  } else {
-    projectName = workspace.workspaceFolders![0].name;
-  }
-
-  return projectName;
+  return packageFile.name || rootFolder.name;
 };


### PR DESCRIPTION
An error occurred when a readme was created and the package did not have a property name

Closes #3