### PR TITLE
🐛 fix: fix badge alignment and license file format

### DIFF
--- a/templates/en/default.md
+++ b/templates/en/default.md
@@ -10,17 +10,11 @@
 
 <p align="center">
   <img alt="Github top language" src="https://img.shields.io/github/languages/top/{{github}}/{{repository}}?color=56BEB8">
-
   <img alt="Github language count" src="https://img.shields.io/github/languages/count/{{github}}/{{repository}}?color=56BEB8">
-
   <img alt="Repository size" src="https://img.shields.io/github/repo-size/{{github}}/{{repository}}?color=56BEB8">
-
   <img alt="License" src="https://img.shields.io/github/license/{{github}}/{{repository}}?color=56BEB8">
-
   <!-- <img alt="Github issues" src="https://img.shields.io/github/issues/{{github}}/{{repository}}?color=56BEB8" /> -->
-
   <!-- <img alt="Github forks" src="https://img.shields.io/github/forks/{{github}}/{{repository}}?color=56BEB8" /> -->
-
   <!-- <img alt="Github stars" src="https://img.shields.io/github/stars/{{github}}/{{repository}}?color=56BEB8" /> -->
 </p>
 
@@ -88,7 +82,7 @@ $ yarn start
 
 ## :memo: License ##
 
-This project is under license from MIT. For more details, see the [LICENSE](LICENSE.md) file.
+This project is under license from MIT. For more details, see the [LICENSE](LICENSE) file.
 
 
 Made with :heart: by <a href="https://github.com/{{github}}" target="_blank">{{author}}</a>

--- a/templates/pt-BR/default.md
+++ b/templates/pt-BR/default.md
@@ -10,17 +10,11 @@
 
 <p align="center">
   <img alt="Principal linguagem do projeto" src="https://img.shields.io/github/languages/top/{{github}}/{{repository}}?color=56BEB8">
-
   <img alt="Quantidade de linguagens utilizadas" src="https://img.shields.io/github/languages/count/{{github}}/{{repository}}?color=56BEB8">
-
   <img alt="Tamanho do repositório" src="https://img.shields.io/github/repo-size/{{github}}/{{repository}}?color=56BEB8">
-
   <img alt="Licença" src="https://img.shields.io/github/license/{{github}}/{{repository}}?color=56BEB8">
-
   <!-- <img alt="Github issues" src="https://img.shields.io/github/issues/{{github}}/{{repository}}?color=56BEB8" /> -->
-
   <!-- <img alt="Github forks" src="https://img.shields.io/github/forks/{{github}}/{{repository}}?color=56BEB8" /> -->
-
   <!-- <img alt="Github stars" src="https://img.shields.io/github/stars/{{github}}/{{repository}}?color=56BEB8" /> -->
 </p>
 
@@ -88,7 +82,7 @@ $ yarn start
 
 ## :memo: Licença ##
 
-Este projeto está sob licença MIT. Veja o arquivo [LICENSE](LICENSE.md) para mais detalhes.
+Este projeto está sob licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.
 
 
 Feito com :heart: por <a href="https://github.com/{{github}}" target="_blank">{{author}}</a>


### PR DESCRIPTION
# This PR fixes these issues:

- Badges do not appear side by side #6

	## In the current version
	
	<img width="703" alt="Screenshot2" src="https://user-images.githubusercontent.com/66560757/202914120-6c89d9d0-8aa9-41a2-8fa2-7afe8566c867.png">
	
	In the current version, the badges do not appear side by side, but one after the other and in an irregular fashion.
	
	## Should be look like 
	
	<img width="696" alt="Screenshot" src="https://user-images.githubusercontent.com/66560757/202914081-f67090f1-75c2-424f-b97d-87eb77dd1b7d.png">
	
	Badges should be seen side by side as in the example, a template file should be fixed for this.


- LICENSE.md is not a default name format for GitHub license files #5

	The default name for license file is not `LICENSE.md` anymore. It is `LINCENSE`. 
	
	When you try to create a new license file on GitHub it would be created with the name `LICENSE`.
	
	It would be great if it is fixed in the template file.